### PR TITLE
Add Ability to Parse Equipped Armour Mods

### DIFF
--- a/Sources/DadKit/Character+Decodable.swift
+++ b/Sources/DadKit/Character+Decodable.swift
@@ -54,6 +54,15 @@ extension Character {
         let currentInstanceIds = equipment.map { ($1.itemInstanceId, $0) }
         itemInstances = currentInstanceIds.reduce(into: [Int: ItemComponents.Instances.Item]()) { $0[$1.1] = itemComponents.instances.data[$1.0] }
 
+        // Parse out the sockets.
+        sockets = itemComponents.sockets.data.compactMap { (key: ItemHash, value: ItemSockets) -> (Int, [ItemSockets.Socket])? in
+            if let itemHash = Int(key) {
+                return (itemHash, value.sockets)
+            } else {
+                return nil
+            }
+        }.reduce(into: [:]) { $0[$1.0] = $1.1 }
+
         //Current character's subclass
         let subclassKey = allEquipment.subclassItem?.itemInstanceId
         let subclassTalentGrid = itemComponents.talentGrids.data.first(where: { $0.key == subclassKey } )?.value

--- a/Tests/DadKitTests/Character.swift
+++ b/Tests/DadKitTests/Character.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import DadKit
+@testable import PromiseKit
 
 class CharacterTests: XCTestCase {
 
@@ -54,6 +55,21 @@ class CharacterTests: XCTestCase {
         let promise = URLSession.shared.dataTask(.promise, with: req).validate()
 
         promise.done { character in
+            x.fulfill()
+        }.catch {
+            XCTFail($0.localizedDescription)
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 10)
+    }
+
+    func test_API_GetCharacterLoadoutResponds200() {
+        let x = expectation(description: "Get full character loadout responds with 200.")
+
+        firstly {
+            Bungie.getCurrentCharacter(for: Player(membershipId: "4611686018467346411", membershipPlatform: .steam))
+        }.done { character in
             x.fulfill()
         }.catch {
             XCTFail($0.localizedDescription)


### PR DESCRIPTION
Fetches all armour mods for each equipped armour piece and appends them to the applicable Items.

This bolts on top of the previous `getLoadout` method and the `Loadout` struct now exposes the armor mods keyed by the armour pieces.